### PR TITLE
Finished, 1: Update gen to make first click non-mine

### DIFF
--- a/gen.lua
+++ b/gen.lua
@@ -1,22 +1,30 @@
-function create_mines(width, height, mines)
+function create_mines(width, height, mines, current)
+    -- store mines
     local grid = {}
 
+    -- keep adding mines until there's enough
     while #grid != mines do
-        printh("---", "log")
+        --printh("---", "log")
+        -- generate a mine location
         local loc = gen(width, height)
-        printh("loc: "..loc[1]..", "..loc[2], "log")
+        --printh("loc: "..loc[1]..", "..loc[2], "log")
 
+        -- check if there's already a mine there, or that's where the player pressed
         local flag = false
         for mine in all(grid) do
-            printh("checking against: "..mine[1]..", "..mine[2], "log")
-            if loc[1] == mine[1] and loc[2] == mine[2] then
-                printh("!!!", "log")
+            --printh("checking against: "..mine[1]..", "..mine[2], "log")
+            if
+            (loc[1] == mine[1] and loc[2] == mine[2]) or
+            (loc[1] == current[1] and loc[2] == current[2]) then
+                --printh("!!!", "log")
+                -- if so, don't add that location to the list
                 flag = true
             end
         end
 
+        -- add valid mines to the list
         if not flag then
-            printh("added!", "log")
+            --printh("added!", "log")
 
             add(grid, loc)
         end

--- a/main.lua
+++ b/main.lua
@@ -71,7 +71,7 @@ function initialise()
     height = 15
 
     -- number of mines
-    mcount = 4
+    mcount = 30
 
     -- number of flags available (automaticall set to no. of mines)
     fcount = mcount
@@ -252,7 +252,8 @@ function _update()
                 
                 if first then
                     -- create a list of mines
-                    mine_list = create_mines(width, height, mcount)
+                    -- pass in current position to ensure no mine spawns there
+                    mine_list = create_mines(width, height, mcount, {p.mx, p.my})
 
                     for mine in all(mine_list) do
                         --printh(mine[1]..", "..mine[2], "log", false)


### PR DESCRIPTION
Fixed bug #1.
Changed functions in `gen.lua` to take in the user's current position when they generate the mine list, and avoids putting a mine there.