### PR TITLE
Finished, 61: Hold to action on win/loss

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -227,12 +227,16 @@ function _update()
     -- allow user to return to title from pico-8 menu
     menuitem(2, "return to title", ensure)
     
-    -- if mouse enabled, capture positions
     if mouse then
+        -- positions
         mo_x = stat(32)
         mo_y = stat(33)
 
-        if not (sticky and stat(34) == 1) then
+        -- left and right click
+        lc = stat(34) == 1
+        rc = stat(34) == 2
+
+        if not (sticky and lc) then
             sticky = false
         end
     end
@@ -287,7 +291,7 @@ function _update()
             hover_replay = (21 <= mo_x and mo_x <= 69) and (57 <= mo_y and mo_y <= 63)
             hover_quit = (21 <= mo_x and mo_x <= 101) and (63 <= mo_y and mo_y <= 70)
 
-            if stat(34) == 1 and not sticky then
+            if lc and not sticky then
                 sticky = true
                 if hover_replay then
                     win = false
@@ -367,7 +371,7 @@ function _update()
             end
             
             -- left click to pick difficulty
-            if stat(34) == 1 and not sticky then
+            if lc and not sticky then
                 -- ensure player click accidentally in next screen
                 sticky = true
 
@@ -432,7 +436,7 @@ function _update()
             p.my = (mo_y - yoff) \ 8
 
             -- if not still pressing key from menu, disable sticky
-            if not (sticky and stat(34) == 1) then
+            if not (lc and sticky) then
                 sticky = false
             end
         end
@@ -502,7 +506,7 @@ function _update()
 
             -- x or right click for flag
             if
-            (btnp("5") or stat(34) == 2) and
+            (btnp("5") or rc) and
             not wait and
             in_bound then
                 -- wait for player to lift key
@@ -533,13 +537,13 @@ function _update()
 
             -- if waiting and user isn't pressing dig, then stop waiting
             -- now allows user to press dig normally
-            if wait == true and stat(34) != 2 then
+            if wait == true and not rc then
                 wait = false
             end
 
             -- o or left click for dig
             if
-            (btnp("4") or (stat(34) == 1 and not sticky)) and
+            (btnp("4") or (lc and not sticky)) and
             not wait and in_bound then
                 sticky = true
                 
@@ -636,7 +640,7 @@ function _update()
             end
             
             -- if left clicking
-            if stat(34) == 1 and not sticky then
+            if lc and not sticky then
                 -- ensure player click accidentally in next screen
                 sticky = true
 
@@ -669,7 +673,7 @@ function _update()
         elseif mouse then
             -- bounds for "return" in guide menu
             hover_return_guide = (92 <= mo_x and mo_x <= 118) and (119 <= mo_y and mo_y <= 123)
-            if stat(34) == 1 and not sticky and hover_return_guide then
+            if lc and not sticky and hover_return_guide then
                 sfx(6)
                 sticky = true
                 guide = false
@@ -732,7 +736,7 @@ function _update()
             end
             
             -- if left clicking
-            if stat(34) == 1 and not sticky then
+            if lc and not sticky then
                 if menu_y == 80 then
                     sfx(5)
                     sticky = true
@@ -1061,6 +1065,7 @@ function _draw()
     print(ticker, 0, 0, 0)
     print("wait: "..tostr(wait))
     print("sticky: "..tostr(sticky))
+    print("lc: "..tostr(lc).." rc: "..tostr(rc))
 end
 
 -- ***********************

--- a/main.lua
+++ b/main.lua
@@ -503,7 +503,8 @@ function _update()
             -- x or right click for flag
             if
             (btnp("5") or stat(34) == 2) and
-            not wait and in_bound then
+            not wait and
+            in_bound then
                 -- wait for player to lift key
                 if stat(34) == 2 then
                     wait = true
@@ -1058,8 +1059,8 @@ function _draw()
     end
     
     print(ticker, 0, 0, 0)
-    print(wait)
-    print(sticky)
+    print("wait: "..tostr(wait))
+    print("sticky: "..tostr(sticky))
 end
 
 -- ***********************

--- a/main.lua
+++ b/main.lua
@@ -116,10 +116,8 @@ function _init()
     bcount = 1
     timer = 0
 
-    -- is the player holding x or o?
-    -- used for win/loss
-    holdx = false
-    holdo = false
+    -- hold to action on win/loss
+    hold_timer = 2
     ticker = 0
 
     --printh("", "log", true)
@@ -273,7 +271,7 @@ function _update()
                     ticker = 0
                 end
 
-                if flr(ticker) == 2 then
+                if flr(ticker) == hold_timer then
                     ticker = 0
 
                     win = false
@@ -296,7 +294,7 @@ function _update()
                     ticker = 0
                 end
 
-                if flr(ticker) == 2 then
+                if flr(ticker) == hold_timer then
                     ticker = 0
 
                     win = false
@@ -816,7 +814,7 @@ function _draw()
         print("you win!", sin(t()*0.5)*10+48, sin(t())*5+47, 2)
 
         -- draw options
-        win_lose_message()
+        win_lose_message(ticker)
         if new_pb then
             pb_message()
         end
@@ -1462,11 +1460,18 @@ function pb_message()
     line(x, y+12, x+12, y+12, 0)
 end
 
-function win_lose_message()
+function win_lose_message(timer)
     if controller then
+        -- draw a bar that fills up while the player holds the button
+        if main then
+            rectfill(21, 57, 21+48*timer/hold_timer, 63, 6)
+        elseif alt then
+            rectfill(21, 64, 21+80*timer/hold_timer, 70, 6)
+        end
+
         -- draw options
         print("❎ to replay", 22, 58, 13)
-        print("🅾️ to return to menu")
+        print("🅾️ to return to menu", 22, 65)
     elseif mouse then
         hover_replay = (21 <= mo_x and mo_x <= 69) and (57 <= mo_y and mo_y <= 63)
         hover_quit = (21 <= mo_x and mo_x <= 101) and (63 <= mo_y and mo_y <= 70)

--- a/main.lua
+++ b/main.lua
@@ -116,6 +116,12 @@ function _init()
     bcount = 1
     timer = 0
 
+    -- is the player holding x or o?
+    -- used for win/loss
+    holdx = false
+    holdo = false
+    ticker = 0
+
     --printh("", "log", true)
 end
 
@@ -234,25 +240,48 @@ function _update()
     if win or lose then
         if controller then
             -- x for return
-            if btnp(5) then
-                win = false
-                lose = false
-                new_pb = false
-                new_theme = false
+            if btn(5) then
+                ticker += 0.1
 
-                initialise(size)
+                if flr(ticker) == 2 then
+                    ticker = 0
+
+                    win = false
+                    lose = false
+                    new_pb = false
+                    new_theme = false
+
+                    sticky = true
+                    wait = true
+                    
+                    initialise(size)
+                end
+            else
+                ticker = 0
             end
 
             -- o for return to menu
             if btnp(4) then
-                win = false
-                lose = false
-                play = false
-                new_pb = false
-                new_theme = false
+                if holdo then
+                    ticker += 0.1
+                else
+                    ticker = 0
+                end
 
-                menu_y = 80
-                menu = true
+                holdo = true
+
+                if ticker == 2 then
+                    win = false
+                    lose = false
+                    play = false
+                    new_pb = false
+                    new_theme = false
+
+                    menu_y = 80
+                    menu = true
+                end
+            else
+                holdo = false
             end
         elseif mouse then
             hover_replay = (21 <= mo_x and mo_x <= 69) and (57 <= mo_y and mo_y <= 63)
@@ -509,7 +538,7 @@ function _update()
 
             -- o or left click for dig
             if
-            (btnp("4") or (stat(34) == 1 and not sticky))and
+            (btnp("4") or (stat(34) == 1 and not sticky)) and
             not wait and in_bound then
                 sticky = true
                 
@@ -779,7 +808,6 @@ function _draw()
 
         -- draw options
         win_lose_message()
-
         if new_pb then
             pb_message()
         end
@@ -1028,6 +1056,10 @@ function _draw()
     if mouse then
         spr(20, mo_x, mo_y)
     end
+    
+    print(ticker, 0, 0, 0)
+    print(wait)
+    print(sticky)
 end
 
 -- ***********************

--- a/main.lua
+++ b/main.lua
@@ -264,10 +264,14 @@ function _update()
 
     if win or lose then
         if controller then
-            -- x for return
-            --[[
-            if x then
-                ticker += 0.1
+            -- x for replay
+            if main then
+                if main_stick then
+                    ticker += 0.1
+                else
+                    main_stick = true
+                    ticker = 0
+                end
 
                 if flr(ticker) == 2 then
                     ticker = 0
@@ -282,23 +286,19 @@ function _update()
                     
                     initialise(size)
                 end
-            else
-                ticker = 0
-            end
-            --]]
-
+            
             -- o for return to menu
-            --[[
-            if o then
-                if holdo then
+            elseif alt then
+                if alt_stick then
                     ticker += 0.1
                 else
+                    alt_stick = true
                     ticker = 0
                 end
 
-                holdo = true
+                if flr(ticker) == 2 then
+                    ticker = 0
 
-                if ticker == 2 then
                     win = false
                     lose = false
                     play = false
@@ -309,9 +309,8 @@ function _update()
                     menu = true
                 end
             else
-                holdo = false
+                ticker = false
             end
-            --]]
         elseif mouse then
             hover_replay = (21 <= mo_x and mo_x <= 69) and (57 <= mo_y and mo_y <= 63)
             hover_quit = (21 <= mo_x and mo_x <= 101) and (63 <= mo_y and mo_y <= 70)
@@ -1068,8 +1067,6 @@ function _draw()
     end
     
     print(ticker, 0, 0, 0)
-    print("main: "..tostr(main).." "..tostr(main_stick))
-    print("alt: "..tostr(alt).." "..tostr(alt_stick))
 end
 
 -- ***********************

--- a/main.lua
+++ b/main.lua
@@ -509,79 +509,6 @@ function _update()
                 p.y += 8
                 p.my += 1
             end
-
-            -- x or right click for flag
-            if main and not main_stick and in_bound then
-                -- wait for player to lift key
-                main_stick = true
-
-                -- if that space hasn't already been dug
-                if not digs[p.mx][p.my] then
-                    -- if there is already a flag there
-                    if flags[p.mx][p.my] == true then
-                        -- remove the flag, and add one to the flag count
-                        sfx(3)
-                        flags[p.mx][p.my] = false
-                        fcount += 1
-                    -- if there wasn't already a flag there...
-                    else
-                        -- if the player still has flags left...
-                        if fcount != 0 then
-                            -- add a flag and take one from the flag count
-                            sfx(1)
-                            flags[p.mx][p.my] = true
-                            fcount -= 1
-                        end
-                    end
-                end
-            end
-
-            -- o or left click for dig
-            if alt and not alt_stick and in_bound then
-                alt_stick = true
-                
-                if first then
-                    -- create a list of mines
-                    -- pass in current position to ensure no mine spawns there
-                    mine_list = create_mines(width, height, mcount, {p.mx, p.my})
-
-                    -- change all the mine positions to true
-                    for mine in all(mine_list) do
-                        --printh(mine[1]..", "..mine[2], "log", false)
-                        grid[mine[1]][mine[2]] = true
-                    end
-
-                    -- fill in the rest of the spaces with numbers for adjacent mines
-                    grid = fill_adj(grid, width, height)
-
-                    first = false
-                    record = flr(t())
-                end
-
-                -- don't try and dig a space with a flag
-                if flags[p.mx][p.my] != true then
-                    for loc in all(mine_list) do
-                        -- if that location is in the mine list...
-                        if loc[1] == p.mx and loc[2] == p.my then
-                            -- the player loses
-                            lose = true
-                        end
-                    end
-
-                    -- if there isn't a mine there, dig that space
-                    if not lose then
-                        --printh("", "log", true)
-
-                        -- if that space hasn't already been dug, play sfx
-                        if digs[p.mx][p.my] != true then
-                            sfx(2)
-                        end
-
-                        -- chain-uncover the rest of the spaces
-                        uncover({p.mx, p.my})
-                    end
-                end
-            end
         elseif mouse then
             -- start at offset
             -- find distance from current mouse to offset
@@ -594,6 +521,79 @@ function _update()
             -- int. div. of 8 to find how many spaces that is
             p.mx = (mo_x - xoff) \ 8 +1
             p.my = (mo_y - yoff) \ 8
+        end
+
+        -- x or left click for flag
+        if main and not main_stick and in_bound then
+            -- wait for player to lift key
+            main_stick = true
+
+            -- if that space hasn't already been dug
+            if not digs[p.mx][p.my] then
+                -- if there is already a flag there
+                if flags[p.mx][p.my] == true then
+                    -- remove the flag, and add one to the flag count
+                    sfx(3)
+                    flags[p.mx][p.my] = false
+                    fcount += 1
+                -- if there wasn't already a flag there...
+                else
+                    -- if the player still has flags left...
+                    if fcount != 0 then
+                        -- add a flag and take one from the flag count
+                        sfx(1)
+                        flags[p.mx][p.my] = true
+                        fcount -= 1
+                    end
+                end
+            end
+        end
+
+        -- o or right click for dig
+        if alt and not alt_stick and in_bound then
+            alt_stick = true
+            
+            if first then
+                -- create a list of mines
+                -- pass in current position to ensure no mine spawns there
+                mine_list = create_mines(width, height, mcount, {p.mx, p.my})
+
+                -- change all the mine positions to true
+                for mine in all(mine_list) do
+                    --printh(mine[1]..", "..mine[2], "log", false)
+                    grid[mine[1]][mine[2]] = true
+                end
+
+                -- fill in the rest of the spaces with numbers for adjacent mines
+                grid = fill_adj(grid, width, height)
+
+                first = false
+                record = flr(t())
+            end
+
+            -- don't try and dig a space with a flag
+            if flags[p.mx][p.my] != true then
+                for loc in all(mine_list) do
+                    -- if that location is in the mine list...
+                    if loc[1] == p.mx and loc[2] == p.my then
+                        -- the player loses
+                        lose = true
+                    end
+                end
+
+                -- if there isn't a mine there, dig that space
+                if not lose then
+                    --printh("", "log", true)
+
+                    -- if that space hasn't already been dug, play sfx
+                    if digs[p.mx][p.my] != true then
+                        sfx(2)
+                    end
+
+                    -- chain-uncover the rest of the spaces
+                    uncover({p.mx, p.my})
+                end
+            end
         end
     elseif menu then
         if controller then
@@ -847,7 +847,7 @@ function _draw()
         print("you lose...", sin(t()*0.5)*6+43, 46, 2)
        
         -- draw options
-        win_lose_message()
+        win_lose_message(ticker)
     elseif difficulty then
         -- draw main frame and background
         if controller then


### PR DESCRIPTION
Implemented issue #61.
Added a timer for actions on win/loss, where the user needs to hold the button down to actually pick it.
Includes issue #65 and major refactoring of code and variable names.