### PR TITLE
Finished, 62: Hide win/loss screen

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -344,14 +344,14 @@ function _update()
                     hover_hide = (92 <= mo_x and mo_x <= 109) and (72 <= mo_y and mo_y <= 77)
                 end
             else
-                hover_hide = (80)
+                hover_hide = (111 <= mo_x and mo_x <= 127) and (122 <= mo_y and mo_y <= 127)
             end
 
             -- if left clicking
             if main and not main_stick then
                 main_stick = true
 
-                if hover_replay then
+                if hover_replay and not hide then
                     win = false
                     lose = false
 
@@ -359,7 +359,7 @@ function _update()
                     new_theme = false
 
                     initialise(size)
-                elseif hover_quit then
+                elseif hover_quit and not hide then
                     win = false
                     lose = false
                     play = false
@@ -1721,7 +1721,6 @@ function draw_win_loss(win)
             elseif mouse then
                 rectfill(92, 72, 109, 77, 9)
                 print("HIDE", 93, 72, 7)
-                
             end
         end
 
@@ -1746,7 +1745,12 @@ function draw_win_loss(win)
         -- draw options
         win_lose_message(ticker)
     else
-        rectfill(99, 121, 127, 127, 9)
-        print("⬆️ SHOW", 100, 122, 7)
+        if controller then
+            rectfill(99, 121, 127, 127, 9)
+            print("⬆️ SHOW", 100, 122, 7)
+        elseif mouse then
+            rectfill(111, 122, 127, 127, 9)
+            print("SHOW", 112, 122, 7)
+        end
     end
 end

--- a/main.lua
+++ b/main.lua
@@ -130,6 +130,9 @@ function _init()
     -- strength of screen shake
     shake_strength = 0
 
+    -- hide the win/loss screen
+    hide = false
+
     printh("", "log", true)
 end
 
@@ -230,6 +233,9 @@ function initialise(diff)
     -- is this the player's first dig?
     -- used to wait to create the mine list
     first = true
+
+    -- always show the win/loss screen by default
+    hide = false
 end
 
 function _update()
@@ -273,6 +279,12 @@ function _update()
 
     if win or lose then
         if controller then
+            if btnp(3) and not hide then
+                hide = true
+            elseif btnp(2) and hide then
+                hide = false
+            end
+
             -- x for replay
             if main then
                 if main_stick then
@@ -859,89 +871,9 @@ end
 
 function _draw()
     if win then
-        -- clear screen with grey background
-        cls(themes[theme_select]["gamebg"])
-
-        -- draw the map
-        map(0, 0, xoff, yoff, width, height+1) 
-        
-        -- draw all dug spaces and flags
-        draw_digs()
-        draw_flags()
-
-        -- print time in top right corner
-        print(mins..secs, 108, 1, 7)
-
-        -- draw flag icon and count in top left corner
-        spr(3, 0, 0)
-        print(fcount, 8, 1, 7)
-
-        -- if a new theme was just unlocked
-        if type(new_theme) == "table" then
-            -- draw message box and border with extra space for theme info
-            rectfill(18, 39, 109, 88, 9)
-            rectfill(19, 40, 108, 87, 7)
-            
-            bprint("new theme!", 37, 76, new_theme["accent"], 3)
-
-            -- theme preview
-            rectfill(82, 75, 88, 81, new_theme["main"])
-
-            pset(82, 75, 7)
-            pset(82, 81, 7)
-            pset(88, 75, 7)
-            pset(88, 81, 7)
-        else
-            -- draw message box and border normally
-            rectfill(18, 39, 109, 72, 9)
-            rectfill(19, 40, 108, 71, 7)
-        end
-
-        -- draw message shadow
-        print("you win!", sin(t()*0.5)*10+49, sin(t())*5+48, 6)
-
-        -- draw message
-        print("you win!", sin(t()*0.5)*10+48, sin(t())*5+47, 2)
-
-        -- draw options
-        win_lose_message(ticker)
-        if new_pb then
-            pb_message()
-        end
+        draw_win_loss(true)
     elseif lose then
-        -- clear screen with grey background
-        cls(themes[theme_select]["gamebg"])
-
-        -- draw the map
-        map(0, 0, xoff, yoff, width, height+1) 
-
-        -- draw all dug spaces and flags
-        draw_digs()
-        draw_flags()
-        foreach(explosions, draw_explosion)
-
-        -- print time in top right corner
-        print(mins..secs, 108, 1, 7)
-
-        -- draw flag icon and count in top left corner
-        spr(3, 0, 0)
-        print(fcount, 8, 1, 7)
-        
-        -- draw explosion particles
-        draw_particles()
-
-        -- draw message box and border
-        rectfill(18, 39, 109, 72, 9)
-        rectfill(19, 40, 108, 71, 7)
-
-        -- draw message shadow
-        print("you lose...", sin(t()*0.5)*6+42, 47, 6)
-
-        -- draw message
-        print("you lose...", sin(t()*0.5)*6+43, 46, 2)
-       
-        -- draw options
-        win_lose_message(ticker)
+        draw_win_loss(false)
     elseif losing then
         camera(0, 0)
 
@@ -1719,4 +1651,78 @@ function shake()
     -- decay the shake scrength
     shake_strength *= 0.75
     if (shake_strength < 0.05) shake_strength = 0
+end
+
+function draw_win_loss(win)
+    -- clear screen with grey background
+    cls(themes[theme_select]["gamebg"])
+
+    -- draw the map
+    map(0, 0, xoff, yoff, width, height+1) 
+
+    -- draw all dug spaces and flags
+    draw_digs()
+    draw_flags()
+    foreach(explosions, draw_explosion) -- explosions too, if lost
+    draw_particles()
+
+    -- print time in top right corner
+    print(mins..secs, 108, 1, 7)
+
+    -- draw flag icon and count in top left corner
+    spr(3, 0, 0)
+    print(fcount, 8, 1, 7)
+
+    if not hide then
+        -- if a new theme was just unlocked
+        if type(new_theme) == "table" then
+            -- draw message box and border with extra space for theme info
+            rectfill(18, 39, 109, 88, 9)
+            rectfill(19, 40, 108, 87, 7)
+            
+            bprint("new theme!", 37, 76, new_theme["accent"], 3)
+
+            -- theme preview
+            rectfill(82, 75, 88, 81, new_theme["main"])
+
+            pset(82, 75, 7)
+            pset(82, 81, 7)
+            pset(88, 75, 7)
+            pset(88, 81, 7)
+
+            rectfill(80, 88, 109, 94, 9)
+            print("⬇️ HIDE", 81, 89, 7)
+        else
+            -- draw message box and border normally
+            rectfill(18, 39, 109, 72, 9)
+            rectfill(19, 40, 108, 71, 7)
+
+            rectfill(80, 72, 109, 78, 9)
+            print("⬇️ HIDE", 81, 73, 7)
+        end
+
+        if win then
+            -- draw message shadow
+            print("you win!", sin(t()*0.5)*10+49, sin(t())*5+48, 6)
+    
+            -- draw message
+            print("you win!", sin(t()*0.5)*10+48, sin(t())*5+47, 2)
+    
+            if new_pb then
+                pb_message()
+            end
+        else
+            -- draw message shadow
+            print("you lose...", sin(t()*0.5)*6+42, 47, 6)
+    
+            -- draw message
+            print("you lose...", sin(t()*0.5)*6+43, 46, 2)
+        end
+    
+        -- draw options
+        win_lose_message(ticker)
+    else
+        rectfill(99, 121, 127, 127, 9)
+        print("⬆️ SHOW", 100, 122, 7)
+    end
 end

--- a/main.lua
+++ b/main.lua
@@ -285,56 +285,67 @@ function _update()
                 hide = false
             end
 
-            -- x for replay
-            if main then
-                if main_stick then
-                    ticker += 0.1
+            if not hide then
+                -- x for replay
+                if main then
+                    if main_stick then
+                        ticker += 0.1
+                    else
+                        main_stick = true
+                        ticker = 0
+                    end
+
+                    if flr(ticker) == hold_timer then
+                        ticker = 0
+
+                        win = false
+                        lose = false
+                        new_pb = false
+                        new_theme = false
+
+                        main_stick = true
+                        alt_stick = true
+                        
+                        initialise(size)
+                    end
+                
+                -- o for return to menu
+                elseif alt then
+                    if alt_stick then
+                        ticker += 0.1
+                    else
+                        alt_stick = true
+                        ticker = 0
+                    end
+
+                    if flr(ticker) == hold_timer then
+                        ticker = 0
+
+                        win = false
+                        lose = false
+                        play = false
+                        new_pb = false
+                        new_theme = false
+
+                        menu_y = 80
+                        menu = true
+                    end
                 else
-                    main_stick = true
-                    ticker = 0
+                    ticker = false
                 end
-
-                if flr(ticker) == hold_timer then
-                    ticker = 0
-
-                    win = false
-                    lose = false
-                    new_pb = false
-                    new_theme = false
-
-                    main_stick = true
-                    alt_stick = true
-                    
-                    initialise(size)
-                end
-            
-            -- o for return to menu
-            elseif alt then
-                if alt_stick then
-                    ticker += 0.1
-                else
-                    alt_stick = true
-                    ticker = 0
-                end
-
-                if flr(ticker) == hold_timer then
-                    ticker = 0
-
-                    win = false
-                    lose = false
-                    play = false
-                    new_pb = false
-                    new_theme = false
-
-                    menu_y = 80
-                    menu = true
-                end
-            else
-                ticker = false
             end
         elseif mouse then
             hover_replay = (21 <= mo_x and mo_x <= 69) and (57 <= mo_y and mo_y <= 63)
             hover_quit = (21 <= mo_x and mo_x <= 101) and (63 <= mo_y and mo_y <= 70)
+            if not hide then
+                if new_theme then
+                    hover_hide = (92 <= mo_x and mo_x <= 109) and (88 <= mo_y and mo_y <= 93)
+                else
+                    hover_hide = (92 <= mo_x and mo_x <= 109) and (72 <= mo_y and mo_y <= 77)
+                end
+            else
+                hover_hide = (80)
+            end
 
             -- if left clicking
             if main and not main_stick then
@@ -357,6 +368,8 @@ function _update()
                     new_theme = false
 
                     menu = true
+                elseif hover_hide then
+                    hide = not hide
                 end
             end
         end
@@ -1690,15 +1703,26 @@ function draw_win_loss(win)
             pset(88, 75, 7)
             pset(88, 81, 7)
 
-            rectfill(80, 88, 109, 94, 9)
-            print("⬇️ HIDE", 81, 89, 7)
+            if controller then
+                rectfill(80, 88, 109, 94, 9)
+                print("⬇️ HIDE", 81, 89, 7)
+            elseif mouse then
+                rectfill(92, 88, 109, 93, 9)
+                print("HIDE", 93, 88, 7)
+            end
         else
             -- draw message box and border normally
             rectfill(18, 39, 109, 72, 9)
             rectfill(19, 40, 108, 71, 7)
 
-            rectfill(80, 72, 109, 78, 9)
-            print("⬇️ HIDE", 81, 73, 7)
+            if controller then
+                rectfill(80, 72, 109, 78, 9)
+                print("⬇️ HIDE", 81, 73, 7)
+            elseif mouse then
+                rectfill(92, 72, 109, 77, 9)
+                print("HIDE", 93, 72, 7)
+                
+            end
         end
 
         if win then


### PR DESCRIPTION
Implemented issue #62.
Player can now show or hide the win/loss screen to see the full game grid.