### PR TITLE
Finished, 69: Skip explosions

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -374,6 +374,11 @@ function _update()
             end
         end
     elseif losing then
+        -- hold x and o to speed up explosions
+        if main and alt then
+            explosion_timer = explosion_interval
+        end
+
         -- when the timer reaches the interval, explode another mine
         if explosion_timer == explosion_interval then
             -- wait for a non-flagged mine

--- a/main.lua
+++ b/main.lua
@@ -375,7 +375,7 @@ function _update()
         end
     elseif losing then
         -- hold x and o to speed up explosions
-        if main and alt then
+        if main then
             explosion_timer = explosion_interval
         end
 


### PR DESCRIPTION
Implemented issue #69.
Player can hold X or left click to speed up mine explosions (on Hard, from about 7 seconds to 2 seconds).