### PR TITLE
Finished, 93: Delete save data

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -10,7 +10,6 @@ function _init()
     printh("", "log", true) -- clear the log
     -- *************
 
-
     -- enable devkit mouse
     poke(0x5F2D, 1)
 
@@ -288,6 +287,9 @@ end
 function _update()
     -- remove "return to title" by default
     menuitem(2)
+
+    -- allow user to delete their save data from pico-8 menu
+    menuitem(5, "delete save data", save_security)
 
     if controller then
         -- control scheme
@@ -2022,6 +2024,37 @@ function to_title(b)
     guide = false
     menu_y = 80
     menu = true
+end
+
+function save_security(b)
+-- check that the user wants to delete their save
+    -- ignore right/left button presses
+    if (b&1 > 0) or (b&2 > 0) then
+        return true
+    end
+
+    -- ask the user to confirm their choice
+    menuitem(5, "100% sure?", delete_save)
+    return true
+end
+
+function delete_save(b)
+-- delete all save data
+    -- ignore right/left button presses
+    if (b&1 > 0) or (b&2 > 0) then
+        return true
+    end
+
+    -- set the option back to normal
+    menuitem(5, "delete save data", save_security)
+    
+    -- delete save data
+    for c=0, 9 do
+        dset(c, 0)
+    end
+
+    -- reset the cart
+    run()
 end
 
 


### PR DESCRIPTION
Implemented issue #93.
Added option to PICO-8 menu to delete the user's save data.