### PR TITLE
Finished, 85: Clicking outside the grid on mouse mode

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1266,9 +1266,11 @@ function _draw()
         end
 
         -- draw square cursor
-        if p.my != 0 then
+        if p.my > 0 then
             spr(17, p.x, p.y)
         end
+
+        print(p.my, 0, 0, 0)
     elseif menu then
         -- draw main frame and background
         if controller then


### PR DESCRIPTION
Didn't implement issue #85, see [this comment](https://github.com/wsasaki01/mini-mines/issues/85#issuecomment-1533780282).

However, did fix an issue where the grid cursor is drawn while hovering over the top bar when using mouse modfe.