### PR TITLE
Finished, 45: First click can be a mine

### DIFF
--- a/gen.lua
+++ b/gen.lua
@@ -1,4 +1,6 @@
 function create_mines(width, height, mines, current)
+    printh("CURRENT[1]: "..current[1], "log")
+    printh("CURRENT[2]: "..current[2], "log")
     -- store mines
     local grid = {}
 
@@ -11,14 +13,16 @@ function create_mines(width, height, mines, current)
 
         -- check if there's already a mine there, or that's where the player pressed
         local flag = false
-        for mine in all(grid) do
-            --printh("checking against: "..mine[1]..", "..mine[2], "log")
-            if
-            (loc[1] == mine[1] and loc[2] == mine[2]) or
-            (loc[1] == current[1] and loc[2] == current[2]) then
-                --printh("!!!", "log")
-                -- if so, don't add that location to the list
-                flag = true
+        if (loc[1] == current[1] and loc[2] == current[2]) then
+            flag = true
+        else
+            for mine in all(grid) do
+                --printh("checking against: "..mine[1]..", "..mine[2], "log")
+                if (loc[1] == mine[1] and loc[2] == mine[2]) then
+                    --printh("!!!", "log")
+                    -- if so, don't add that location to the list
+                    flag = true
+                end
             end
         end
 

--- a/main.lua
+++ b/main.lua
@@ -12,6 +12,18 @@ function _init()
     printh("", "log", true) -- clear the log
     -- *************
 
+    debug_count_thing = 0
+    for i=1, 10000 do
+        local temp = create_mines(7, 7, 5, {4, 4})
+        for mine in all(temp) do
+            printh(mine[1].."-"..mine[2], "log")
+            if mine[1] == 4 and mine[2] == 4 then
+                printh("HERE!!!!!!!!!", "log")
+                debug_count_thing += 1
+            end
+        end
+    end
+
     -- enable devkit mouse
     poke(0x5F2D, 1)
 
@@ -128,15 +140,11 @@ function _init()
         local count = 0
         for theme in all(diff_themes) do
             count += 1
-            printh("checking: "..diff_name.." - "..count, "log")
             if dget(theme["id"]) == 1 then
-                printh("already unlocked!!", "log")
-                printh("original length: "..#unlockable[diff_name], "log")
                 -- add the new theme to the player's collection
                 add(themes, theme)
                 -- remove it from the original list
                 del(unlockable[diff_name], theme)
-                printh("new length: "..#unlockable[diff_name], "log")
             end
         end
     end

--- a/main.lua
+++ b/main.lua
@@ -2,9 +2,10 @@ function _init()
     -- *************
     --     DEBUG
     -- *************
-    reveal = false -- reveal mine locations during game
+    reveal = true -- reveal mine locations during game
     fill = false -- show values for each space
-    mouse_log = false -- print mouse coords
+    grid_log = true -- print grid position
+    mouse_log = true -- print mouse coords
     title_only = false -- for capturing gifs
     one_mine = false -- only one mine
 
@@ -1371,10 +1372,8 @@ function _draw()
         spr(20, mo_x, mo_y)
     end
 
-    -- debug: print mouse coords
-    if mouse_log then
-        draw_mouse_coords()
-    end
+    -- debug: print mouse and/or grid coords
+    draw_coords()
 end
 
 -- ***********************
@@ -2091,8 +2090,17 @@ function draw_matrix()
     end
 end
 
-function draw_mouse_coords()
+function draw_coords()
 -- draw mouse coords in top left corner
-    print(mo_x, 0, 0, 0)
-    print(mo_y)
+    cursor(0, 0, 0)
+
+    if mouse_log then
+        print(mo_x)
+        print(mo_y)
+    end
+
+    if grid_log and play then
+        print(p.mx)
+        print(p.my)
+    end
 end


### PR DESCRIPTION
Fixed bug #45, finally!
While generating the minefield, the validation for the current player position was found within a for loop that iterated through the current grid matrix, to check against past mines and prevent duplicates. However, when the very first mine was being generated, that for loop wouldn't be run (since the grid matrix has length 0), meaning very rarely, the first mine added could be the player's current position.

Now, that validation is found before the for loop, so even when the first mine is being generated, it will never be the player position.